### PR TITLE
fixed mongodb session not closing bug - Issue #48

### DIFF
--- a/skeleton/conf/mongoconfig.go.template
+++ b/skeleton/conf/mongoconfig.go.template
@@ -28,7 +28,8 @@ func GetMongoSession() (*mgo.Session, error) {
 	}
 
 	LoadMongoConfig()
-	mgoSession, erro := mgo.Dial(mongoDbURI)
+	var erro error
+	mgoSession, erro = mgo.Dial(mongoDbURI)
 	if erro != nil {
 		log.Printf("[GetMongoSession] Erro ao tentar abrir a sessao com o Mongo: [%s]\n", erro.Error())
 		return nil, erro


### PR DESCRIPTION
Apparently, on line 31, when you did `mgoSession, erro := mgo.Dial(mongoDbURI)`, go was creating a new local-scoped `mgoSession`, instead of using the package-scoped one.

The package-scoped `mgoSession` was always nil, and the code never entered the `if` block on line 25.
The result was that in every call to `GetMongoSession()`, a new session was opened, then `Copy()`ed, creating 2 sessions. The copy session was closed by the caller code, but the other one remained open.

Replacing `:=` by `=` on seemed to fix the issue, but then a new `var erro error` nedded to be added.